### PR TITLE
fix(oas3): allow for array schema type and string example

### DIFF
--- a/src/execute/index.js
+++ b/src/execute/index.js
@@ -310,25 +310,32 @@ export function buildRequest(options) {
     if (typeof value === 'undefined' && parameter.required && !parameter.allowEmptyValue) {
       throw new Error(`Required parameter ${parameter.name} is not provided`);
     }
+    // case for mismatch between example type and schema type
+    const isSchemaTypeExampleTypeMismatch =
+      has('type', parameter.schema) &&
+      parameter.schema.type === 'array' &&
+      typeof parameter.schema.example === 'string';
 
     if (specIsOAS3 && typeof value === 'string') {
-      if (
-        has('type', parameter.schema) &&
-        typeof parameter.schema.type === 'string' &&
-        findObjectOrArraySchema(parameter.schema, { recurse: false })
-      ) {
-        value = parseJsonObjectOrArray({ value, silentFail: false });
-      } else if (
-        has('type', parameter.schema) &&
-        Array.isArray(parameter.schema.type) &&
-        findObjectOrArraySchema(parameter.schema, { recurse: false })
-      ) {
-        value = parseJsonObjectOrArray({ value, silentFail: true });
-      } else if (
-        !has('type', parameter.schema) &&
-        findObjectOrArraySchema(parameter.schema, { recurse: true })
-      ) {
-        value = parseJsonObjectOrArray({ value, silentFail: true });
+      if (!isSchemaTypeExampleTypeMismatch) {
+        if (
+          has('type', parameter.schema) &&
+          typeof parameter.schema.type === 'string' &&
+          findObjectOrArraySchema(parameter.schema, { recurse: false })
+        ) {
+          value = parseJsonObjectOrArray({ value, silentFail: false });
+        } else if (
+          has('type', parameter.schema) &&
+          Array.isArray(parameter.schema.type) &&
+          findObjectOrArraySchema(parameter.schema, { recurse: false })
+        ) {
+          value = parseJsonObjectOrArray({ value, silentFail: true });
+        } else if (
+          !has('type', parameter.schema) &&
+          findObjectOrArraySchema(parameter.schema, { recurse: true })
+        ) {
+          value = parseJsonObjectOrArray({ value, silentFail: true });
+        }
       }
     }
 

--- a/test/oas3/execute/style-explode/query.js
+++ b/test/oas3/execute/style-explode/query.js
@@ -1124,6 +1124,50 @@ describe('OAS 3.0 - buildRequest w/ `style` & `explode` - query parameters', () 
         headers: {},
       });
     });
+
+    test('should build a query parameter when schema type is array and example type is string', () => {
+      // Given
+      const spec = {
+        openapi: '3.0.0',
+        paths: {
+          '/users': {
+            get: {
+              operationId: 'myOperation',
+              parameters: [
+                {
+                  in: 'query',
+                  name: 'test',
+                  required: true,
+                  schema: {
+                    type: 'array',
+                    example: 'test1',
+                    items: {
+                      type: 'string',
+                      enum: ['test1', 'test2', 'test3'],
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        },
+      };
+      // when
+      const req = buildRequest({
+        spec,
+        operationId: 'myOperation',
+        parameters: {
+          test: 'test1',
+        },
+      });
+
+      expect(req).toEqual({
+        method: 'GET',
+        url: `/users?test=test1`,
+        credentials: 'same-origin',
+        headers: {},
+      });
+    });
   });
   describe('object values', () => {
     const VALUE = {


### PR DESCRIPTION
Do not throw an error and allow the request to build if the schema type is an array even when the example provided is a string

### Description
Allow building request same as was before this PR https://github.com/swagger-api/swagger-js/pull/3826

### Motivation and Context
Before https://github.com/swagger-api/swagger-js/pull/3826 has been introduced, it was possible to still send request when the schema type is an array even when the example provided is a string

### How Has This Been Tested?
Manually and unit test

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (changes to documentation, CI, metadata, etc)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
